### PR TITLE
Brunnhilde version 1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - cd sleuthkit && ./bootstrap && ./configure && make && sudo make install && sudo ldconfig
   - cd ..
 install:
-  - pip install wget
+  - pip install requests
 script:
   - python test.py
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Brunnhilde - A reporting companion to Siegfried  
 
-### Version: Brunnhilde 1.7.2
+### Version: Brunnhilde 1.8.0
 
 [![Build Status](https://travis-ci.org/timothyryanwalsh/brunnhilde.svg?branch=master)](https://travis-ci.org/timothyryanwalsh/brunnhilde)
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ For Brunnhilde to report on any directory of content, the following must be inst
 
 * Python (2.7 or 3.4+; Python 3 is recommended)
 * [Siegfried](http://www.itforarchivists.com/siegfried): Brunnhilde is now compatible with all version of Siegfried, including 1.6+. It does not support MIME-Info or FDD signatures: for Brunnhilde to work, Siegfried must be using the PRONOM signature file only. If you have been using MIME-Info or FDD signatures as a replacement for or alongside PRONOM with Siegfried 1.5/1.6 on your machine, entering `roy build -multi 0` in the terminal should return you to Siegfried's default PRONOM-only identification mode and allow Brunnhilde to work properly.  
-* [wget Python module](https://pypi.org/project/wget/): For downloading CSS and JS files for HTML report from this repository. This should be automatically installed as a dependency when Brunnhilde is installed via pip.
+* [requests Python module](https://pypi.org/project/requests/): For downloading CSS and JS files for HTML report from this repository. This should be automatically installed as a dependency when Brunnhilde is installed via pip.
 
 #### Additional dependencies (for full functionality in Linux and macOS)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ usage: brunnhilde.py [-h] [-a] [-b] [--ssn_mode SSN_MODE] [-d] [--hfs]
                      [--resforks] [--tsk_imgtype TSK_IMGTYPE]
                      [--tsk_fstype TSK_FSTYPE]
                      [--tsk_sector_offset TSK_SECTOR_OFFSET] [--hash HASH]
-                     [--largefiles] [-n] [-r] [-t] [-V] [-w] [-z]
+                     [-k] [-l] [-n] [-r] [-t] [-V] [-w] [-z]
+                     [--save_assets SAVE_ASSETS] [--load_assets LOAD_ASSETS]
                      source destination basename
 
 positional arguments:
@@ -94,6 +95,14 @@ optional arguments:
   -w, --showwarnings    Add Siegfried warnings to HTML report
   -z, --scanarchives    Decompress and scan zip, tar, gzip, warc, arc with
                         Siegfried
+  --save_assets SAVE_ASSETS
+                        Specify filepath location to save JS/CSS files for use
+                        in subsequent runs (this directory should not yet
+                        exist)
+  --load_assets LOAD_ASSETS
+                        Specify filepath location of JS/CSS files to copy to
+                        destination (instead of downloading)
+
 
 ```  
   
@@ -187,6 +196,15 @@ To extract AppleDouble resource forks from HFS-formatted disk images, pass the `
 ### Dependencies
 
 All dependencies are already installed in BitCurator 1.7.106+. See instructions below for installing dependencies if you wish to use Brunnhilde in a different environment (Linux, Mac, or Windows).
+
+#### Internet connection
+
+In order to ensure that the CSS and JavaScript files needed for the Brunnhilde HTML report are included with the report and thus not a preservation risk themselves, these files are downloaded from this Github repository every time Brunnhilde runs.
+
+If you want to run Brunnhilde without an internet connection:
+
+* The first time you run Brunnhilde, use the `save_assets` argument to specify a directory to which Brunnhilde can copy the CSS and JS assets needed for the report. This can be a relative or absolute path. Ideally this path should be memorable and should not yet exist.
+* In subsequent runs, use the `load_assets` argument to specify a directory from which Brunnhilde can copy the CSS and JS assets rather than downloading them from Github. This removes the need for an internet connection when running Brunnhilde after the first time.
 
 #### Core requirements (all operating systems)  
 

--- a/README.md
+++ b/README.md
@@ -199,12 +199,12 @@ All dependencies are already installed in BitCurator 1.7.106+. See instructions 
 
 #### Internet connection
 
-In order to ensure that the CSS and JavaScript files needed for the Brunnhilde HTML report are included with the report and thus not a preservation risk themselves, these files are downloaded from this Github repository every time Brunnhilde runs.
+In order to ensure that the CSS and JavaScript files needed for the Brunnhilde HTML report are included with the report and thus not a preservation risk, these assets are downloaded from this Github repository every time Brunnhilde runs.
 
 If you want to run Brunnhilde without an internet connection:
 
-* The first time you run Brunnhilde, use the `save_assets` argument to specify a directory to which Brunnhilde can copy the CSS and JS assets needed for the report. This can be a relative or absolute path. Ideally this path should be memorable and should not yet exist.
-* In subsequent runs, use the `load_assets` argument to specify a directory from which Brunnhilde can copy the CSS and JS assets rather than downloading them from Github. This removes the need for an internet connection when running Brunnhilde after the first time.
+* The first time you run Brunnhilde, use the `--save_assets` argument to specify a directory to which Brunnhilde can copy the CSS and JS assets needed for the report. This can be a relative or absolute path. Ideally this path should be memorable and should not yet exist.
+* In subsequent runs, use the `--load_assets` argument to specify a directory from which Brunnhilde can copy the CSS and JS assets rather than downloading them from Github. This removes the need for an internet connection when running Brunnhilde after the first time.
 
 #### Core requirements (all operating systems)  
 

--- a/brunnhilde.py
+++ b/brunnhilde.py
@@ -737,7 +737,7 @@ def main():
                 download_asset_file(a['url'], a['filepath'])
             print("\nDownloads complete.")
         except Exception:
-            print("\nERROR: Unable to download required CSS and JS files. Please ensure your internet connection is working and try again.")
+            print("\nERROR: Unable to download required CSS and JS files. Please ensure your internet connection is working and try again or specify the path to where files can be copied from locally with the --load_assets argument.")
             sys.exit(1)
 
         # save a copy locally if option is selected by user

--- a/brunnhilde.py
+++ b/brunnhilde.py
@@ -635,7 +635,7 @@ def _make_parser(version):
 
 def main():
     # system info
-    brunnhilde_version = 'brunnhilde 1.7.2'
+    brunnhilde_version = 'brunnhilde 1.8.0'
     siegfried_version = subprocess.check_output(["sf", "-version"]).decode()
 
     parser = _make_parser(brunnhilde_version)

--- a/brunnhilde.py
+++ b/brunnhilde.py
@@ -721,7 +721,7 @@ def main():
             download_asset_file(a['url'], a['filepath'])
         print("\nDownloads complete.")
     except Exception:
-        print("Unable to download required CSS and JS files. Please ensure your internet connection is working and try again.")
+        print("\nUnable to download required CSS and JS files. Please ensure your internet connection is working and try again.")
         sys.exit(1)
 
     # create html report

--- a/brunnhilde.py
+++ b/brunnhilde.py
@@ -721,7 +721,7 @@ def main():
             download_asset_file(a['url'], a['filepath'])
         print("\nDownloads complete.")
     except Exception:
-        print("\nUnable to download required CSS and JS files. Please ensure your internet connection is working and try again.")
+        print("\nERROR: Unable to download required CSS and JS files. Please ensure your internet connection is working and try again.")
         sys.exit(1)
 
     # create html report

--- a/brunnhilde.py
+++ b/brunnhilde.py
@@ -26,11 +26,11 @@ from itertools import islice
 import math
 import os
 import re
+import requests
 import shutil
 import sqlite3
 import subprocess
 import sys
-import wget
 
 def run_siegfried(args, source_dir, use_hash):
     """Run siegfried on directory"""
@@ -594,6 +594,12 @@ def write_pronom_links(old_file, new_file):
     in_file.close()
     out_file.close()
 
+def download_asset_file(asset_url, asset_filepath):
+    """Download file from asset_url and write to asset_filepath"""
+    r = requests.get(asset_url)
+    with open(asset_filepath, "wb") as f:
+        f.write(r.content)
+
 def close_files_conns_on_exit(html, conn, cursor, report_dir):
     cursor.close()
     conn.close()
@@ -691,17 +697,28 @@ def main():
         os.makedirs(newdir)
 
     # download assets
-    bootstrap_css_url = 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/css/bootstrap.min.css'
-    bootstrap_js_url = 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/js/bootstrap.min.js'
-    jquery_url = 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/js/jquery-3.3.1.slim.min.js'
-    popper_url = 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/js/popper.min.js'
-
+    assets_to_download = [
+        {
+            'filepath': os.path.join(css, 'bootstrap.min.css'),
+            'url': 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/css/bootstrap.min.css'
+        },
+        {
+            'filepath': os.path.join(js, 'bootstrap.min.js'),
+            'url': 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/js/bootstrap.min.js'
+        },
+        {
+            'filepath': os.path.join(js, 'jquery-3.3.1.slim.min.js'),
+            'url': 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/js/jquery-3.3.1.slim.min.js'
+        },
+        {
+            'filepath': os.path.join(js, 'popper.min.js'),
+            'url': 'https://github.com/timothyryanwalsh/brunnhilde/blob/master/assets/js/popper.min.js'
+        }
+    ]
     print("\nDownloading CSS and JS files from Github...")
     try:
-        wget.download(bootstrap_css_url, os.path.join(css, 'bootstrap.min.css'))
-        wget.download(bootstrap_js_url, os.path.join(js, 'bootstrap.min.js'))
-        wget.download(jquery_url, os.path.join(js, 'jquery-3.3.1.slim.min.js'))
-        wget.download(popper_url, os.path.join(js, 'popper.min.js'))
+        for a in assets_to_download:
+            download_asset_file(a['url'], a['filepath'])
         print("\nDownloads complete.")
     except Exception:
         print("Unable to download required CSS and JS files. Please ensure your internet connection is working and try again.")

--- a/brunnhilde.py
+++ b/brunnhilde.py
@@ -259,7 +259,7 @@ def get_stats(args, source_dir, scan_started, cursor, html, brunnhilde_version, 
     html.write('\n<head>')
     html.write('\n<title>Brunnhilde report: %s</title>' % basename)
     html.write('\n<meta http-equiv="Content-Type" content="text/html; charset=utf-8">')
-    html.write('\n<link rel="stylesheet" href="./assets/css/bootstrap.min.css">')
+    html.write('\n<link rel="stylesheet" href="./.assets/css/bootstrap.min.css">')
     html.write('\n</head>')
     html.write('\n<body style="padding-top: 80px">')
     # navbar
@@ -547,9 +547,9 @@ def close_html(html):
     html.write('\n</div>')
     html.write('\n</div>')
     html.write('\n</div>')
-    html.write('\n<script src="./assets/js/jquery-3.3.1.slim.min.js"></script>')
-    html.write('\n<script src="./assets/js/popper.min.js"></script>')
-    html.write('\n<script src="./assets/js/bootstrap.min.js"></script>')
+    html.write('\n<script src="./.assets/js/jquery-3.3.1.slim.min.js"></script>')
+    html.write('\n<script src="./.assets/js/popper.min.js"></script>')
+    html.write('\n<script src="./.assets/js/bootstrap.min.js"></script>')
     html.write('\n<script>$(".navbar-nav .nav-link").on("click", function(){ $(".navbar-nav").find(".active").removeClass("active"); $(this).addClass("active"); });</script>')
     html.write('\n<script>$(".navbar-brand").on("click", function(){ $(".navbar-nav").find(".active").removeClass("active"); });</script>')
     html.write('\n</body>')
@@ -688,7 +688,7 @@ def main():
                 raise
 
     # create assets dirs
-    assets_target = os.path.join(report_dir, 'assets')
+    assets_target = os.path.join(report_dir, '.assets')
     if os.path.exists(assets_target):
         shutil.rmtree(assets_target)
     css = os.path.join(assets_target, 'css')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'brunnhilde',
-    version = '1.7.2',
+    version = '1.8.0',
     url = 'https://github.com/timothyryanwalsh/brunnhilde',
     author = 'Tim Walsh',
     author_email = 'timothyryanwalsh@gmail.com',
@@ -11,7 +11,7 @@ setup(
     description = 'A Siegfried-based digital archives reporting tool for directories and disk images',
     keywords = 'archives reporting characterization identification diskimages',
     platforms = ['POSIX', 'Windows'],
-    install_requires=['wget'],
+    install_requires=['requests'],
     test_suite='test',
     classifiers = [
         'Development Status :: 5 - Production/Stable',

--- a/test.py
+++ b/test.py
@@ -75,6 +75,16 @@ class TestBrunnhildeIntegration(SelfCleaningTestCase):
         if not sys.platform.startswith('win'):
             self.assertTrue(os.path.isfile(j(self.dest_tmpdir, 'test', 
                 'tree.txt')))
+        # bootstrap css/js
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'test', 
+            '.assets', 'css', 'bootstrap.min.css')))
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'test', 
+            '.assets', 'js', 'bootstrap.min.js')))
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'test', 
+            '.assets', 'js', 'jquery-3.3.1.slim.min.js')))
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'test', 
+            '.assets', 'js', 'popper.min.js')))
+
 
     def test_integration_outputs_created_diskimage(self):
         subprocess.call('python brunnhilde.py -nd ./test-data/diskimages/sample-floppy-fat.dd "%s" test' % (self.dest_tmpdir), 
@@ -167,8 +177,18 @@ class TestBrunnhildeIntegration(SelfCleaningTestCase):
             shell=True)
         subprocess.call('python brunnhilde.py --load_assets "%s" ./test-data/files/ "%s" load-test' % (assets_dir, self.dest_tmpdir), 
             shell=True)
+        # report
         self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'load-test', 
             'report.html')))
+        # bootstrap css/js
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'load-test', 
+            '.assets', 'css', 'bootstrap.min.css')))
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'load-test', 
+            '.assets', 'js', 'bootstrap.min.js')))
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'load-test', 
+            '.assets', 'js', 'jquery-3.3.1.slim.min.js')))
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'load-test', 
+            '.assets', 'js', 'popper.min.js')))
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -135,6 +135,16 @@ class TestBrunnhildeIntegration(SelfCleaningTestCase):
         with open(virus_log, 'r') as f:
             self.assertTrue("Infected files: 0" in f.read())
 
+    def test_integration_clamav_largefiles(self):
+        subprocess.call('python brunnhilde.py -l ./test-data/files/ "%s" test' % (self.dest_tmpdir), 
+            shell=True)
+        # virus log correctly written
+        virus_log = j(self.dest_tmpdir, 'test', 'logs', 'viruscheck-log.txt')
+        with open(virus_log, 'r') as f:
+            self.assertTrue("Scanned files: 4" in f.read())
+        with open(virus_log, 'r') as f:
+            self.assertTrue("Infected files: 0" in f.read())
+
     def test_integration_clamav_diskimage(self):
         subprocess.call('python brunnhilde.py -d ./test-data/diskimages/sample-floppy-fat.dd "%s" test' % (self.dest_tmpdir), 
             shell=True)

--- a/test.py
+++ b/test.py
@@ -151,6 +151,15 @@ class TestBrunnhildeIntegration(SelfCleaningTestCase):
         self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'test', 
             'siegfried.sqlite')))
 
+    def test_integration_save_load_assets(self):
+        assets_dir = os.path.join(self.dest_tmpdir, 'assets_test')
+        subprocess.call('python brunnhilde.py --save_assets "%s" ./test-data/files/ "%s" save-test' % (assets_dir, self.dest_tmpdir), 
+            shell=True)
+        subprocess.call('python brunnhilde.py --load_assets "%s" ./test-data/files/ "%s" load-test' % (assets_dir, self.dest_tmpdir), 
+            shell=True)
+        self.assertTrue(is_non_zero_file(j(self.dest_tmpdir, 'load-test', 
+            'report.html')))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Addresses [Issue 38](https://github.com/timothyryanwalsh/brunnhilde/issues/38) by:
	* Replacing the `wget` Python module with `requests` (removing the cryptic "-1/unknown" terminal output and improving handling of downloads)
	* Adding `--save_assets` and `--load_assets` arguments that allow users to cache and retrieve the HTML report's Bootstrap CSS and JavaScript dependencies at a local filepath of their choosing, removing [the need for an internet connection to use Brunnhilde](https://github.com/timothyryanwalsh/brunnhilde/issues/38). Previously, Brunnhilde HTML reports linked out to CDNs to render correctly; this was seen to be a preservation risk. The default behavior remains for Brunnhilde to download its Bootstrap dependencies from the Brunnhilde Github repository on each run.
* Renames the `assets` directory to hidden directory `.assets`.
* Fixes a bug in the display of Social Security Numbers found by bulk_extractor in the Brunnhilde HTML report.
* Renames the "PII" section of the Brunnhilde HTML report to "SSNs", more accurately reflecting the content being displayed, which is currently only Social Security Numbers. Other features found by bulk_extractor can be found in the `bulk_extractor` output directory.